### PR TITLE
Crossing out of runway

### DIFF
--- a/src/libdataxp/xpAirportReader.cpp
+++ b/src/libdataxp/xpAirportReader.cpp
@@ -37,6 +37,16 @@ static const unordered_map<string, Aircraft::OperationType> aircraftOperationTyp
     {"military", Aircraft::OperationType::Military},
 };
 
+// Approximate width of a taxiway
+static const unordered_map<string, int> taxiwayWidthHint = {
+    {"taxiway_A", 10},
+    {"taxiway_B", 20},
+    {"taxiway_C", 30},
+    {"taxiway_D", 40},
+    {"taxiway_E", 50},
+    {"taxiway_F", 60},
+};
+
 static constexpr int DATUM_UNSPECIFIED = -10000;
 
 static void parseSeparatedList(
@@ -333,6 +343,7 @@ void XPAirportReader::parseTaxiEdge1202(istream& input)
 {
     int nodeId1;
     int nodeId2;
+    int widthHint = 0;
     string direction;
     string typeString;
     string name;
@@ -345,6 +356,8 @@ void XPAirportReader::parseTaxiEdge1202(istream& input)
         ? TaxiEdge::Type::Runway 
         : TaxiEdge::Type::Taxiway);
 
+    tryGetValue(taxiwayWidthHint, typeString, widthHint);
+    
     int edgeId = m_nextEdgeId++;
     auto edge = shared_ptr<TaxiEdge>(new TaxiEdge(
         edgeId, 
@@ -352,8 +365,9 @@ void XPAirportReader::parseTaxiEdge1202(istream& input)
         nodeId1, 
         nodeId2, 
         type, 
+        isOneWay,
         {},
-        isOneWay));
+        widthHint));
     
     m_taxiEdges.push_back(edge);
 
@@ -386,8 +400,8 @@ void XPAirportReader::parseGroundEdge1206(istream &input)
         nodeId1, 
         nodeId2, 
         TaxiEdge::Type::Groundway, 
-        {},
-        isOneWay));
+        isOneWay,
+        {}));
     
     m_taxiEdges.push_back(edge);
 }

--- a/src/libworld/libworld.h
+++ b/src/libworld/libworld.h
@@ -2252,6 +2252,7 @@ namespace world
         float m_heading;
         int m_nodeId1;
         int m_nodeId2;
+        int m_widthHint;
         shared_ptr<TaxiNode> m_node1;
         shared_ptr<TaxiNode> m_node2;
         shared_ptr<Runway> m_runway;
@@ -2266,7 +2267,8 @@ namespace world
             const int _nodeId2,
             Type _type = Type::Taxiway,
             bool _isOneWay = false,
-            float _lengthMeters = 0
+            float _lengthMeters = 0,
+            int _widthHint = 0
         );
         TaxiEdge(const UniPoint& _fromPoint, const UniPoint& _toPoint);
         TaxiEdge(shared_ptr<TaxiEdge> _source, bool _flippingOver);
@@ -2286,6 +2288,7 @@ namespace world
         shared_ptr<Runway> runway() const { return m_runway; }
         const ActiveZoneMatrix& activeZones() const { return m_activeZones; }
         Flight::Phase flightPhaseAllocation() const { return m_flightPhaseAllocation; }
+        int widthHint() const {return m_widthHint; }
     public:
         bool isRunway(const string& runwayEndName) const { return m_runwayEndName == runwayEndName; }
         bool isHighSpeedExitRunway(const string& runwayName) const { return m_highSpeedExitRunway == runwayName; }

--- a/src/libworld/libworld.h
+++ b/src/libworld/libworld.h
@@ -521,6 +521,7 @@ namespace world
             double minLongitude = 0;
             double maxLongitude = 0;
         public:
+            void calculate(const GeoPoint& end1, const GeoPoint& end2, float heading1_2, float widthMeters, float marginMeters);
             bool contains(const GeoPoint& p) const;
         };
     private:
@@ -530,6 +531,8 @@ namespace world
         End m_end1; //the lesser heading end
         End m_end2; //the greater heading end
         vector<shared_ptr<TaxiEdge>> m_edges;
+        vector<shared_ptr<TaxiEdge>> m_activeZones;
+        unordered_map<shared_ptr<TaxiEdge>, Bounds> m_activeBounds;
         Bitmask m_maskBit;
         Bounds m_bounds;
     public:
@@ -544,6 +547,9 @@ namespace world
         Bitmask maskBit() const { return m_maskBit; }
         const vector<shared_ptr<TaxiEdge>>& edges() const { return m_edges; }
         const Bounds& bounds() const { return m_bounds; }
+        void appendActiveZone(shared_ptr<TaxiEdge> edge);
+        bool activeZonesContains(const GeoPoint location);
+
     public:
         void calculateBounds();
     private:

--- a/src/libworld/taxiEdge.cpp
+++ b/src/libworld/taxiEdge.cpp
@@ -17,11 +17,13 @@ namespace world
         const int _nodeId2,
         Type _type,
         bool _isOneWay,
-        float _lengthMeters
+        float _lengthMeters,
+        int _widthHint
     ) : m_id(_id),
         m_name(_name),
         m_nodeId1(_nodeId1),
         m_nodeId2(_nodeId2),
+        m_widthHint(_widthHint),
         m_type(_type),
         m_isOneWay(_isOneWay),
         m_lengthMeters(_lengthMeters),
@@ -41,6 +43,7 @@ namespace world
         m_nodeId2(_flippingOver ? _source->m_nodeId1 : _source->m_nodeId2),
         m_node1(_flippingOver ? _source->m_node2 : _source->m_node1),
         m_node2(_flippingOver ? _source->m_node1 : _source->m_node2),
+        m_widthHint(_source->m_widthHint),
         m_highSpeedExitRunway(_source->m_highSpeedExitRunway),
         m_activeZones(_source->m_activeZones),
         m_flightPhaseAllocation(_source->m_flightPhaseAllocation),
@@ -57,6 +60,7 @@ namespace world
         m_heading(GeoMath::getHeadingFromPoints(_fromPoint.geo(), _toPoint.geo())),
         m_nodeId1(-1),
         m_nodeId2(-1),
+        m_widthHint(0),
         m_node1(make_shared<TaxiNode>(-1, _fromPoint)),
         m_node2(make_shared<TaxiNode>(-1, _toPoint)),
         m_flightPhaseAllocation(Flight::Phase::NotAssigned)

--- a/src/libworld/worldBuilder.cpp
+++ b/src/libworld/worldBuilder.cpp
@@ -378,7 +378,7 @@ namespace world
             }
         };
 
-        const auto resolveActiveZoneMask = [&airport](ActiveZoneMask& mask) {
+        const auto resolveActiveZoneMask = [&airport](ActiveZoneMask& mask, shared_ptr<TaxiEdge> edge) {
             mask.m_runwaysMask = 0;
 
             if (mask.m_runwayNames.size() > 0)
@@ -387,6 +387,8 @@ namespace world
                 {
                     const auto& runway = airport->getRunwayOrThrow(name);
                     mask.m_runwaysMask |= runway->m_maskBit;
+                    
+                    runway->appendActiveZone(edge);
                 }
             }
         };
@@ -451,9 +453,9 @@ namespace world
                 break;
             }
 
-            resolveActiveZoneMask(edge->m_activeZones.departue);
-            resolveActiveZoneMask(edge->m_activeZones.arrival);
-            resolveActiveZoneMask(edge->m_activeZones.ils);
+            resolveActiveZoneMask(edge->m_activeZones.departue, edge);
+            resolveActiveZoneMask(edge->m_activeZones.arrival, edge);
+            resolveActiveZoneMask(edge->m_activeZones.ils, edge);
         };
 
         const auto resolveAllEdgeRunways = [=]() {


### PR DESCRIPTION
Fixes #235 

- Links taxi edges with active zones to their runways
- Planes cleared to cross and crossing position are checked on the runway and these linked taxiways edges