### PR TITLE
Load apt.dat from custom scenery

### DIFF
--- a/src/libloaders/CMakeLists.txt
+++ b/src/libloaders/CMakeLists.txt
@@ -3,8 +3,10 @@ project(libloaders VERSION 0.1.0)
 
 add_library(libloaders STATIC 
     libdataxp.h
+    tokenValueFileReaderBase.cpp
     xpAirportReader.cpp
     xpFmsxReader.cpp
+    xpSceneryPacksIniReader.cpp
     libopenflights.hpp
 )
 

--- a/src/libloaders/libdataxp.h
+++ b/src/libloaders/libdataxp.h
@@ -74,6 +74,7 @@ private:
     void parseGroundEdge1206(istream &input);
     void parseRunwayActiveZone1204(istream& input, shared_ptr<TaxiEdge> edge);
     void parseStartupLocation1300(istream &input);
+    void parseStartupLocation15(istream &input);
     void parseMetadata1302(istream &input);
     void parseControlFrequency(int lineCode, istream &input);
     bool isControlFrequencyLine(int lineCode);
@@ -106,15 +107,37 @@ public:
         const AirportLoadedCallback& onAirportLoaded);
 };
 
-class XPFmsxReader
+class XPSceneryAptDatReader
 {
 private:
+    const shared_ptr<HostServices> m_host;
+public:
+    explicit XPSceneryAptDatReader(shared_ptr<HostServices> _host);
+public:
+    void readSceneryAirports(
+        const XPAirportReader::QueryAirspaceCallback& onQueryAirspace,
+        const XPAirportReader::FilterAirportCallback& onFilterAirport,
+        const XPAptDatReader::AirportLoadedCallback& onAirportLoaded);
+private:
+    void loadSceneryFolderList(vector<string>& list);
+    shared_ptr<istream> tryOpenAptDat(const string& sceneryFolder);
+};
+
+class TokenValueFileReaderBase
+{
+protected:
     struct Line
     {
         string token;
         string suffix;
         char delimiter;
     };
+protected:
+    void parseInputLines(istream& input, vector<Line>& lines);
+};
+
+class XPFmsxReader : TokenValueFileReaderBase
+{
 private:
     shared_ptr<HostServices> m_host;
 public:
@@ -122,7 +145,6 @@ public:
 public:
     shared_ptr<FlightPlan> readFrom(istream& input);
 private:
-    void parseInputLines(istream& input, vector<Line>& lines);
     void addValue(shared_ptr<FlightPlan> plan, const string& key, const string& value);
     bool isFmsFormat(const vector<Line>& lines);
     bool isFmxFormat(const vector<Line>& lines);
@@ -132,4 +154,14 @@ private:
     static int countCharOccurrences(const string& s, char c);
     static string trimLead(const string& s, const string& prefix);
     static string getRunwayFromApproachName(const string &approachName);
+};
+
+class XPSceneryPacksIniReader : TokenValueFileReaderBase
+{
+private:
+    shared_ptr<HostServices> m_host;
+public:
+    XPSceneryPacksIniReader(shared_ptr<HostServices> _host);
+public:
+    void readSceneryFolderList(istream& input, vector<string>& sceneryFolders);
 };

--- a/src/libloaders/tokenValueFileReaderBase.cpp
+++ b/src/libloaders/tokenValueFileReaderBase.cpp
@@ -1,0 +1,48 @@
+//
+// This file is part of AT&C project which simulates virtual world of air traffic and ATC.
+// Code licensing terms are available at https://github.com/felix-b/atc/blob/master/LICENSE
+//
+#include <system_error>
+#include "stlhelpers.h"
+#include "libworld.h"
+#include "libdataxp.h"
+
+using namespace std;
+using namespace world;
+
+void TokenValueFileReaderBase::parseInputLines(istream &input, vector<Line> &lines)
+{
+    while (!input.eof() && !input.bad())
+    {
+        string text;
+
+        try
+        {
+            getline(input, text);
+        }
+        catch(const exception &e)
+        {
+            break;
+        }
+
+        const char *delimiterChars = ",: ";
+        size_t delimitierIndex = text.find_first_of(delimiterChars);
+        int lastNonSpaceIndex = delimitierIndex == string::npos ? -1 : (int)text.length() - 1;
+
+        while (lastNonSpaceIndex >= 0 && strchr(delimiterChars, text.at(lastNonSpaceIndex)))
+        {
+            lastNonSpaceIndex--;
+        }
+
+        if (delimitierIndex != string::npos && delimitierIndex < lastNonSpaceIndex)
+        {
+            string token = text.substr(0, delimitierIndex);
+            string suffix = text.substr(delimitierIndex + 1, lastNonSpaceIndex - delimitierIndex);
+
+            if (!token.empty())
+            {
+                lines.push_back({ token, suffix, text.at(delimitierIndex) });
+            }
+        }
+    }
+}

--- a/src/libloaders/tokenValueFileReaderBase.cpp
+++ b/src/libloaders/tokenValueFileReaderBase.cpp
@@ -26,10 +26,11 @@ void TokenValueFileReaderBase::parseInputLines(istream &input, vector<Line> &lin
         }
 
         const char *delimiterChars = ",: ";
+        const char *whitespaceChars = "\r\n\t ";
         size_t delimitierIndex = text.find_first_of(delimiterChars);
         int lastNonSpaceIndex = delimitierIndex == string::npos ? -1 : (int)text.length() - 1;
 
-        while (lastNonSpaceIndex >= 0 && strchr(delimiterChars, text.at(lastNonSpaceIndex)))
+        while (lastNonSpaceIndex >= 0 && strchr(whitespaceChars, text.at(lastNonSpaceIndex)))
         {
             lastNonSpaceIndex--;
         }

--- a/src/libloaders/xpFmsxReader.cpp
+++ b/src/libloaders/xpFmsxReader.cpp
@@ -3,8 +3,6 @@
 // Code licensing terms are available at https://github.com/felix-b/atc/blob/master/LICENSE
 //
 #include <memory>
-#include <iostream>
-#include <utility>
 #include <system_error>
 #include "stlhelpers.h"
 #include "libworld.h"
@@ -41,43 +39,6 @@ shared_ptr<FlightPlan> XPFmsxReader::readFrom(istream &input)
     }
 
     return plan;
-}
-
-void XPFmsxReader::parseInputLines(istream &input, vector<Line> &lines)
-{
-    while (!input.eof() && !input.bad())
-    {
-        string text;
-
-        try
-        {
-            getline(input, text);
-        }
-        catch(const exception &e)
-        {
-            break;
-        }
-
-        const char *delimiterChars = ",: ";
-        size_t delimitierIndex = text.find_first_of(delimiterChars);
-        size_t lastNonSpaceIndex = text.length() - 1;
-
-        while (lastNonSpaceIndex >= 0 && strchr(delimiterChars, text.at(lastNonSpaceIndex)))
-        {
-            lastNonSpaceIndex--;
-        }
-
-        if (delimitierIndex != text.npos && delimitierIndex < lastNonSpaceIndex)
-        {
-            string token = text.substr(0, delimitierIndex);
-            string suffix = text.substr(delimitierIndex + 1, lastNonSpaceIndex - delimitierIndex);
-
-            if (!token.empty())
-            {
-                lines.push_back({ token, suffix, text.at(delimitierIndex) });
-            }
-        }
-    }
 }
 
 bool XPFmsxReader::isFmsFormat(const vector<Line> &lines)

--- a/src/libloaders/xpSceneryPacksIniReader.cpp
+++ b/src/libloaders/xpSceneryPacksIniReader.cpp
@@ -1,0 +1,34 @@
+//
+// This file is part of AT&C project which simulates virtual world of air traffic and ATC.
+// Code licensing terms are available at https://github.com/felix-b/atc/blob/master/LICENSE
+//
+#include <memory>
+#include <iostream>
+#include <utility>
+#include <system_error>
+#include "stlhelpers.h"
+#include "libworld.h"
+#include "libdataxp.h"
+
+using namespace std;
+using namespace world;
+
+XPSceneryPacksIniReader::XPSceneryPacksIniReader(shared_ptr<HostServices> _host) :
+    m_host(_host)
+{
+}
+
+void XPSceneryPacksIniReader::readSceneryFolderList(istream& input, vector<string>& sceneryFolders)
+{
+    vector<Line> iniLines;
+    parseInputLines(input, iniLines);
+
+    for (const Line& line : iniLines)
+    {
+        if (line.token == "SCENERY_PACK" && line.suffix.length() > 0)
+        {
+            sceneryFolders.push_back(line.suffix);
+        }
+    }
+}
+

--- a/src/libloaders_test/CMakeLists.txt
+++ b/src/libloaders_test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(libloaders_test
     xpAirportReaderTest.cpp
     airportOpsTest.cpp
     xpFmsxReaderTest.cpp
+    xpSceneryPacksIniReaderTest.cpp
     hydrationTest.cpp
     openflightsTest.cpp
 )

--- a/src/libloaders_test/CMakeLists.txt
+++ b/src/libloaders_test/CMakeLists.txt
@@ -7,6 +7,7 @@ enable_testing()
 
 add_executable(libloaders_test
     libdataxp_test.h
+    testHelpers.cpp
     cppTest.cpp
     xpAirportReaderTest.cpp
     airportOpsTest.cpp

--- a/src/libloaders_test/libdataxp_test.h
+++ b/src/libloaders_test/libdataxp_test.h
@@ -4,6 +4,7 @@
 //
 #pragma once
 
+#include <string>
 #include <fstream>
 #include <sstream>
 #include <vector>
@@ -20,6 +21,8 @@ stringstream makeAptDat(const vector<string>& lines);
 shared_ptr<HostServices> makeHost();
 shared_ptr<ControlledAirspace> makeAirspace(double centerLat, double centerLon, float radiusNm, const string& name);
 void openTestInputStream(const string& fileName, ifstream& str);
+string getTestInputFilePath(const string& fileName);
+string getTestOutputFilePath(const string& fileName);
 void assertRunwaysExist(shared_ptr<Airport> airport, const vector<string>& names);
 void assertGatesExist(shared_ptr<Airport> airport, const vector<string>& names);
 void assertTaxiEdgesExist(shared_ptr<Airport> airport, const unordered_set<string>& names);

--- a/src/libloaders_test/openflightsTest.cpp
+++ b/src/libloaders_test/openflightsTest.cpp
@@ -2,6 +2,7 @@
 #include "libworld.h"
 #include "libworld_test.h"
 #include "libopenflights.hpp"
+#include "libdataxp_test.h"
 #include <fstream>
 
 stringstream makeStream(const vector<string> &lines)
@@ -32,7 +33,7 @@ protected:
         {
             auto ofreader = OpenFlightDataReader(m_host);
 
-            m_routeFinder = ofreader.getRoutes("./testInputs/openflights", {});
+            m_routeFinder = ofreader.getRoutes(getTestInputFilePath("openflights"), {});
         }
     }
 
@@ -134,14 +135,14 @@ TEST_F(OpenFlightsRoutesTest, checkAircraftFiltering)
     static shared_ptr<WorldRoutes> b738Finder;
     auto ofreader = OpenFlightDataReader(m_host);
 
-    ASSERT_NO_THROW(b738Finder = ofreader.getRoutes("./testInputs/openflights", {"B738"}));
+    ASSERT_NO_THROW(b738Finder = ofreader.getRoutes(getTestInputFilePath("openflights"), {"B738"}));
     ASSERT_EQ(b738Finder->routesToCount("KJFK"), 8);
     ASSERT_EQ(b738Finder->routesToCount("KWAL"), 1);
 
     static shared_ptr<WorldRoutes> a320Finder;
     ofreader = OpenFlightDataReader(m_host);
 
-    ASSERT_NO_THROW(a320Finder = ofreader.getRoutes("./testInputs/openflights", {"A320"}));
+    ASSERT_NO_THROW(a320Finder = ofreader.getRoutes(getTestInputFilePath("openflights"), {"A320"}));
     ASSERT_EQ(a320Finder->routesToCount("KJFK"), 0);
     ASSERT_EQ(a320Finder->routesToCount("KWAL"), 1);
     
@@ -156,7 +157,7 @@ TEST_F(OpenFlightsRoutesTest, checkRandomness)
     shared_ptr<WorldRoutes> s1Finder;
     auto ofreader = OpenFlightDataReader(m_host);
     auto rng1 = default_random_engine(1);
-    ASSERT_NO_THROW(s1Finder = ofreader.getRoutes("./testInputs/openflights", {}, rng1));
+    ASSERT_NO_THROW(s1Finder = ofreader.getRoutes(getTestInputFilePath("openflights"), {}, rng1));
     size_t nbRoutes = s1Finder->routesToCount("KJFK");
 
     m_host->writeLog("TEST|  Sequence 1");
@@ -179,7 +180,7 @@ TEST_F(OpenFlightsRoutesTest, checkRandomness)
     shared_ptr<WorldRoutes> s2Finder;
     ofreader = OpenFlightDataReader(m_host);
     auto rng2 = default_random_engine(2);
-    ASSERT_NO_THROW(s2Finder = ofreader.getRoutes("./testInputs/openflights", {}, rng2));
+    ASSERT_NO_THROW(s2Finder = ofreader.getRoutes(getTestInputFilePath("openflights"), {}, rng2));
     ASSERT_EQ(s2Finder->routesToCount("KJFK"), nbRoutes);
 
     m_host->writeLog("TEST|  Sequence 2");

--- a/src/libloaders_test/testHelpers.cpp
+++ b/src/libloaders_test/testHelpers.cpp
@@ -1,0 +1,147 @@
+// 
+// This file is part of AT&C project which simulates virtual world of air traffic and ATC.
+// Code licensing terms are available at https://github.com/felix-b/atc/blob/master/LICENSE
+// 
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <unordered_set>
+#include "gtest/gtest.h"
+#include "libworld.h"
+#include "libdataxp.h"
+#include "libworld_test.h"
+#include "libdataxp_test.h"
+
+using namespace world;
+using namespace std;
+
+shared_ptr<HostServices> makeHost()
+{
+    return make_shared<TestHostServices>();
+}
+
+shared_ptr<ControlledAirspace> makeAirspace(
+    double centerLat, 
+    double centerLon, 
+    float radiusNm, 
+    const string& name)
+{
+    GeoPolygon airspaceBounds({ 
+        GeoPolygon::circleEdge(GeoPoint(centerLat, centerLon), radiusNm)
+    });
+    auto airspaceGeometry = shared_ptr<AirspaceGeometry>(new AirspaceGeometry(airspaceBounds, false, 0, true, 10000));
+    auto airspace = shared_ptr<ControlledAirspace>(new ControlledAirspace(
+        1, 
+        "USA", 
+        "TST", 
+        name, 
+        name, 
+        ControlledAirspace::Type::ControlZone, 
+        AirspaceClass::ClassB, 
+        airspaceGeometry));
+    return airspace;
+}
+
+stringstream makeAptDat(const vector<string>& lines)
+{
+    stringstream output;
+    output.exceptions(ios::failbit | ios::badbit);
+
+    for (const auto& line : lines)
+    {
+        output << line << endl;
+    }
+
+    output.seekg(0);
+    return output;
+}
+
+string getTestInputFilePath(const string& fileName)
+{
+    return "../../src/libloaders_test/testInputs/" + fileName;
+}
+
+string getTestOutputFilePath(const string& fileName)
+{
+    return "../../src/libloaders_test/testOutputs/" + fileName;
+}
+
+void openTestInputStream(const string& fileName, ifstream& str)
+{
+    string fullPath = getTestInputFilePath(fileName);
+    str.exceptions(ifstream::failbit | ifstream::badbit);
+    str.open(fullPath.c_str());
+}
+
+void assertRunwaysExist(shared_ptr<Airport> airport, const vector<string>& names)
+{
+    for (const string& name : names)
+    {
+        try
+        {
+            auto runway = airport->getRunwayOrThrow(name);
+            runway->getEndOrThrow(name);
+        }
+        catch (const exception& e)
+        {
+            stringstream message;
+            message << "assertRunwaysExist FAILED name [" << name << "] error [" << e.what() << "]";
+            throw runtime_error(message.str());
+        }
+    }
+}
+
+void assertGatesExist(shared_ptr<Airport> airport, const vector<string>& names)
+{
+    for (const string& name : names)
+    {
+        try
+        {
+            airport->getParkingStandOrThrow(name);
+        }
+        catch (const exception& e)
+        {
+            stringstream message;
+            message << "assertGatesExist FAILED name [" << name << "] error [" << e.what() << "]";
+            throw runtime_error(message.str());
+        }
+    }
+}
+
+void assertTaxiEdgesExist(shared_ptr<Airport> airport, const unordered_set<string>& names)
+{
+    unordered_set<string> remainingNames = names;
+
+    for (auto edge : airport->taxiNet()->edges())
+    {
+        if (edge->type() == TaxiEdge::Type::Taxiway)
+        {
+            remainingNames.erase(edge->name());
+        }
+    }
+
+    if (!remainingNames.empty())
+    {
+        stringstream message;
+        message << "assertTaxiEdgesExist FAILED missing:";
+        for (const auto& name : remainingNames)
+        {
+            message << " [" << name << "]";
+        }
+        throw runtime_error(message.str());
+    }
+}
+
+// void writeAirportJson(shared_ptr<const Airport> airport, ostream& output)
+// {
+//     console::JsonWriter writer(output);
+//     console::JsonProtocol protocol(writer);
+//     protocol.writeAirport(airport);
+// }
+
+// void writeTaxiPathJson(shared_ptr<const TaxiPath> taxiPath, ostream& output)
+// {
+//     console::JsonWriter writer(output);
+//     console::JsonProtocol protocol(writer);
+//     protocol.writeTaxiPath(taxiPath);
+// }

--- a/src/libloaders_test/testInputs/scenery_packs.ini
+++ b/src/libloaders_test/testInputs/scenery_packs.ini
@@ -1,0 +1,11 @@
+I
+1000 Version
+SCENERY
+
+SCENERY_PACK Custom Scenery/My Scenery One/
+SCENERY_PACK_DISABLED Custom Scenery/My Scenery Two/
+SCENERY_PACK Custom Scenery/MySceneryThree/
+SCENERY_PACK Custom Scenery/Global Airports/
+SCENERY_PACK Custom Scenery/My Scenery Four/
+SCENERY_PACK_DISABLED Custom Scenery/zzz_hd_global_scenery4/
+SCENERY_PACK Custom Scenery/My Scenery Five/

--- a/src/libloaders_test/xpAirportReaderTest.cpp
+++ b/src/libloaders_test/xpAirportReaderTest.cpp
@@ -580,11 +580,11 @@ TEST(XPAirportReaderTest, findTaxiPath_KJFK_1) {
     XPAirportReader reader(makeHost());
     ifstream aptDat;
     aptDat.exceptions(ifstream::failbit | ifstream::badbit);
-    aptDat.open("../../src/libloaders_test/testInputs/apt_kjfk.dat");
+    aptDat.open(getTestInputFilePath("apt_kjfk.dat"));
     reader.readAirport(aptDat);
     ofstream jsonOutput;
     jsonOutput.exceptions(ofstream::failbit | ofstream::badbit);
-    jsonOutput.open("../../src/libloaders_test/testOutputs/taxi_kjfk_79_378.json", std::ios_base::out | std::ios_base::trunc);
+    jsonOutput.open(getTestOutputFilePath("taxi_kjfk_79_378.json"), std::ios_base::out | std::ios_base::trunc);
     
     const auto airport = reader.getAirport();
     const auto taxiNet = airport->taxiNet();
@@ -600,11 +600,11 @@ TEST(XPAirportReaderTest, findTaxiPath_KJFK_2) {
     XPAirportReader reader(makeHost());
     ifstream aptDat;
     aptDat.exceptions(ifstream::failbit | ifstream::badbit);
-    aptDat.open("../../src/libloaders_test/testInputs/apt_kjfk.dat");
+    aptDat.open(getTestInputFilePath("apt_kjfk.dat"));
     reader.readAirport(aptDat);
     ofstream jsonOutput;
     jsonOutput.exceptions(ofstream::failbit | ofstream::badbit);
-    jsonOutput.open("../../src/libloaders_test/testOutputs/taxi_kjfk_79_581.json", std::ios_base::out | std::ios_base::trunc);
+    jsonOutput.open(getTestOutputFilePath("taxi_kjfk_79_581.json"), std::ios_base::out | std::ios_base::trunc);
     
     const auto airport = reader.getAirport();
     const auto taxiNet = airport->taxiNet();
@@ -889,130 +889,10 @@ TEST(XPAptDatReaderTest, readAll_realDefaultAptDat)
 }
 #endif
 
-shared_ptr<HostServices> makeHost()
-{
-    return make_shared<TestHostServices>();
-}
-
-shared_ptr<ControlledAirspace> makeAirspace(
-    double centerLat, 
-    double centerLon, 
-    float radiusNm, 
-    const string& name)
-{
-    GeoPolygon airspaceBounds({ 
-        GeoPolygon::circleEdge(GeoPoint(centerLat, centerLon), radiusNm)
-    });
-    auto airspaceGeometry = shared_ptr<AirspaceGeometry>(new AirspaceGeometry(airspaceBounds, false, 0, true, 10000));
-    auto airspace = shared_ptr<ControlledAirspace>(new ControlledAirspace(
-        1, 
-        "USA", 
-        "TST", 
-        name, 
-        name, 
-        ControlledAirspace::Type::ControlZone, 
-        AirspaceClass::ClassB, 
-        airspaceGeometry));
-    return airspace;
-}
-
-stringstream makeAptDat(const vector<string>& lines)
-{
-    stringstream output;
-    output.exceptions(ios::failbit | ios::badbit);
-
-    for (const auto& line : lines)
-    {
-        output << line << endl;
-    }
-
-    output.seekg(0);
-    return output;
-}
-
-void openTestInputStream(const string& fileName, ifstream& str)
-{
-    string fullPath = "../../src/libloaders_test/testInputs/" + fileName;
-    str.exceptions(ifstream::failbit | ifstream::badbit);
-    str.open(fullPath.c_str());
-}
-
 void createTestOutputStream(const string& fileName, ofstream& str)
 {
-    string fullPath = "../../src/libloaders_test/testInputs/" + fileName;
+    string fullPath = getTestInputFilePath(fileName);
     str.exceptions(ofstream::failbit | ofstream::badbit);
     str.open(fullPath.c_str(), ofstream::out | ofstream::trunc);
 }
 
-void assertRunwaysExist(shared_ptr<Airport> airport, const vector<string>& names)
-{
-    for (const string& name : names)
-    {
-        try
-        {
-            auto runway = airport->getRunwayOrThrow(name);
-            runway->getEndOrThrow(name);
-        }
-        catch (const exception& e)
-        {
-            stringstream message;
-            message << "assertRunwaysExist FAILED name [" << name << "] error [" << e.what() << "]";
-            throw runtime_error(message.str());
-        }
-    }
-}
-
-void assertGatesExist(shared_ptr<Airport> airport, const vector<string>& names)
-{
-    for (const string& name : names)
-    {
-        try
-        {
-            airport->getParkingStandOrThrow(name);
-        }
-        catch (const exception& e)
-        {
-            stringstream message;
-            message << "assertGatesExist FAILED name [" << name << "] error [" << e.what() << "]";
-            throw runtime_error(message.str());
-        }
-    }
-}
-
-void assertTaxiEdgesExist(shared_ptr<Airport> airport, const unordered_set<string>& names)
-{
-    unordered_set<string> remainingNames = names;
-
-    for (auto edge : airport->taxiNet()->edges())
-    {
-        if (edge->type() == TaxiEdge::Type::Taxiway)
-        {
-            remainingNames.erase(edge->name());
-        }
-    }
-
-    if (!remainingNames.empty())
-    {
-        stringstream message;
-        message << "assertTaxiEdgesExist FAILED missing:";
-        for (const auto& name : remainingNames)
-        {
-            message << " [" << name << "]";
-        }
-        throw runtime_error(message.str());
-    }
-}
-
-// void writeAirportJson(shared_ptr<const Airport> airport, ostream& output)
-// {
-//     console::JsonWriter writer(output);
-//     console::JsonProtocol protocol(writer);
-//     protocol.writeAirport(airport);
-// }
-
-// void writeTaxiPathJson(shared_ptr<const TaxiPath> taxiPath, ostream& output)
-// {
-//     console::JsonWriter writer(output);
-//     console::JsonProtocol protocol(writer);
-//     protocol.writeTaxiPath(taxiPath);
-// }

--- a/src/libloaders_test/xpAirportReaderTest.cpp
+++ b/src/libloaders_test/xpAirportReaderTest.cpp
@@ -501,6 +501,47 @@ TEST(XPAirportReaderTest, readAptDat_parkingStands) {
     //writeAirportJson(airport, cout);
 }
 
+TEST(XPAirportReaderTest, readAptDat_parkingStands_oldCode15) {
+    XPAirportReader reader(makeHost());
+    stringstream aptDat = makeAptDat({
+        "15  40.100 -073.200 152.39 T1 5",
+        "15  40.110 -073.220 105.95 T1 3",
+    });
+
+    reader.readAirport(aptDat);
+    const auto airport = reader.getAirport();
+    const vector<shared_ptr<ParkingStand>>& parkingStands = airport->parkingStands();
+
+    shared_ptr<ParkingStand> gate_t15 = airport->getParkingStandOrThrow("T1 5");
+    shared_ptr<ParkingStand> gate_t13 = airport->getParkingStandOrThrow("T1 3");
+
+    ASSERT_EQ(parkingStands.size(), 2);
+    EXPECT_EQ(parkingStands[0], gate_t15);
+    EXPECT_EQ(parkingStands[1], gate_t13);
+
+    EXPECT_EQ(gate_t15->id(), 301);
+    EXPECT_EQ(gate_t15->name(), "T1 5");
+    EXPECT_EQ(gate_t15->type(), ParkingStand::Type::Unknown);
+    EXPECT_FLOAT_EQ(gate_t15->location().latitude(), 40.100);
+    EXPECT_FLOAT_EQ(gate_t15->location().longitude(), -73.200);
+    EXPECT_FLOAT_EQ(gate_t15->heading(), 152.39);
+    EXPECT_EQ(gate_t15->widthCode(), "F");
+    EXPECT_EQ(gate_t15->aircraftCategories(), Aircraft::Category::All);
+    EXPECT_EQ(gate_t15->operationTypes(), Aircraft::OperationType::All);
+    EXPECT_TRUE(gate_t15->airlines().empty());
+
+    EXPECT_EQ(gate_t13->id(), 302);
+    EXPECT_EQ(gate_t13->name(), "T1 3");
+    EXPECT_EQ(gate_t13->type(), ParkingStand::Type::Unknown);
+    EXPECT_FLOAT_EQ(gate_t13->location().latitude(), 40.110);
+    EXPECT_FLOAT_EQ(gate_t13->location().longitude(), -73.220);
+    EXPECT_FLOAT_EQ(gate_t13->heading(), 105.95);
+    EXPECT_EQ(gate_t13->widthCode(), "F");
+    EXPECT_EQ(gate_t13->aircraftCategories(), Aircraft::Category::All);
+    EXPECT_EQ(gate_t13->operationTypes(), Aircraft::OperationType::All);
+    EXPECT_TRUE(gate_t13->airlines().empty());
+}
+
 TEST(XPAirportReaderTest, readAptDat_skipUnrecognizedLines) {
     XPAirportReader builder(makeHost());
     stringstream aptDat = makeAptDat({

--- a/src/libloaders_test/xpSceneryPacksIniReaderTest.cpp
+++ b/src/libloaders_test/xpSceneryPacksIniReaderTest.cpp
@@ -1,0 +1,35 @@
+//
+// This file is part of AT&C project which simulates virtual world of air traffic and ATC.
+// Code licensing terms are available at https://github.com/felix-b/atc/blob/master/LICENSE
+//
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <unordered_set>
+#include "gtest/gtest.h"
+#include "libworld.h"
+#include "libdataxp.h"
+#include "libworld_test.h"
+#include "libdataxp_test.h"
+
+using namespace world;
+using namespace std;
+
+
+TEST(XPSceneryPacksIniReaderTest, readSceneryPacksIni) {
+    auto host = TestHostServices::createWithWorld();
+    ifstream iniFile;
+    openTestInputStream("scenery_packs.ini", iniFile);
+
+    vector<string> sceneryFolders;
+    XPSceneryPacksIniReader reader(host);
+    reader.readSceneryFolderList(iniFile, sceneryFolders);
+
+    ASSERT_EQ(sceneryFolders.size(), 5);
+
+    EXPECT_EQ(sceneryFolders.at(0), "Custom Scenery/My Scenery One/");
+    EXPECT_EQ(sceneryFolders.at(1), "Custom Scenery/MySceneryThree/");
+    EXPECT_EQ(sceneryFolders.at(2), "Custom Scenery/Global Airports/");
+    EXPECT_EQ(sceneryFolders.at(3), "Custom Scenery/My Scenery Four/");
+    EXPECT_EQ(sceneryFolders.at(4), "Custom Scenery/My Scenery Five/");
+}

--- a/src/libworld/libworld.h
+++ b/src/libworld/libworld.h
@@ -1554,6 +1554,7 @@ namespace world
             Airline = 0x02,
             Cargo = 0x04,
             Military = 0x08,
+            All = 0x01 | 0x02 | 0x04 | 0x08
         };
         enum class LightBits
         {
@@ -2539,11 +2540,13 @@ namespace world
             const string& operatorIcao,
             const string& tailNo,
             Aircraft::Category category) = 0;
+        virtual string combineFilePath(const string& basePath, const vector<string>& relativePathParts) = 0;
         virtual string pathAppend(const string &rootPath, const vector<string>& relativePathParts) = 0;
         virtual string getResourceFilePath(const vector<string>& relativePathParts) = 0;
         virtual string getHostFilePath(const vector<string>& relativePathParts) = 0;
         virtual vector<string> findFilesInHostDirectory(const vector<string>& relativePathParts) = 0;
         virtual shared_ptr<istream> openFileForRead(const string& filePath) = 0;
+        virtual bool checkFileExists(const string& filePath) = 0;
         virtual void showMessageBox(const string& title, const char *format, ...) = 0;
         virtual void writeLog(const char* format, ...) = 0;
     public:

--- a/src/libworld/libworld.h
+++ b/src/libworld/libworld.h
@@ -2540,7 +2540,6 @@ namespace world
             const string& operatorIcao,
             const string& tailNo,
             Aircraft::Category category) = 0;
-        virtual string combineFilePath(const string& basePath, const vector<string>& relativePathParts) = 0;
         virtual string pathAppend(const string &rootPath, const vector<string>& relativePathParts) = 0;
         virtual string getResourceFilePath(const vector<string>& relativePathParts) = 0;
         virtual string getHostFilePath(const vector<string>& relativePathParts) = 0;

--- a/src/libworld_test/libworld_test.h
+++ b/src/libworld_test/libworld_test.h
@@ -308,6 +308,16 @@ namespace world
             cout.flush();
         }
 
+        string combineFilePath(const string& basePath, const vector<string>& relativePathParts) override
+        {
+            string fullPath = basePath;
+            for (const string& part : relativePathParts)
+            {
+                fullPath.append("/");
+                fullPath.append(part);
+            }
+            return fullPath;
+        }
         string pathAppend(const string &rootPath, const vector<string>& relativePathParts)
         {
             string fullPath = rootPath;
@@ -337,6 +347,10 @@ namespace world
             file->exceptions(ifstream::failbit | ifstream::badbit);
             file->open(filePath);
             return file;
+        }
+        bool checkFileExists(const string& filePath) override
+        {
+            return true;
         }
         void showMessageBox(const string& title, const char *format, ...) override
         {

--- a/src/libworld_test/libworld_test.h
+++ b/src/libworld_test/libworld_test.h
@@ -308,16 +308,6 @@ namespace world
             cout.flush();
         }
 
-        string combineFilePath(const string& basePath, const vector<string>& relativePathParts) override
-        {
-            string fullPath = basePath;
-            for (const string& part : relativePathParts)
-            {
-                fullPath.append("/");
-                fullPath.append(part);
-            }
-            return fullPath;
-        }
         string pathAppend(const string &rootPath, const vector<string>& relativePathParts)
         {
             string fullPath = rootPath;

--- a/src/pluginxp/pluginHostServices.hpp
+++ b/src/pluginxp/pluginHostServices.hpp
@@ -140,17 +140,6 @@ public:
         return services().get<AIAircraftFactory>()->createAircraft(modelIcao, operatorIcao, tailNo, category);
     }
 
-    string combineFilePath(const string& basePath, const vector<string>& relativePathParts) override
-    {
-        string fullPath = basePath;
-        for (const string& part : relativePathParts)
-        {
-            fullPath.append(m_directorySeparator);
-            fullPath.append(part);
-        }
-        return fullPath;
-    }
-	
     string pathAppend(const string &rootPath, const vector<string>& relativePathParts)
     {
         string fullPath = rootPath;

--- a/src/pluginxp/pluginHostServices.hpp
+++ b/src/pluginxp/pluginHostServices.hpp
@@ -140,6 +140,17 @@ public:
         return services().get<AIAircraftFactory>()->createAircraft(modelIcao, operatorIcao, tailNo, category);
     }
 
+    string combineFilePath(const string& basePath, const vector<string>& relativePathParts) override
+    {
+        string fullPath = basePath;
+        for (const string& part : relativePathParts)
+        {
+            fullPath.append(m_directorySeparator);
+            fullPath.append(part);
+        }
+        return fullPath;
+    }
+	
     string pathAppend(const string &rootPath, const vector<string>& relativePathParts)
     {
         string fullPath = rootPath;
@@ -202,6 +213,12 @@ public:
         file->exceptions(ifstream::failbit | ifstream::badbit);
         file->open(filePath);
         return file;
+    }
+
+    bool checkFileExists(const string& filePath) override
+    {
+        ifstream f(filePath.c_str());
+        return f.good();
     }
 
     void showMessageBox(const string& title, const char *format, ...) override


### PR DESCRIPTION
Fixes #254 

What I do in this PR:
- Stop reading the big apt.dat from Resources/default scenery/default apt dat
- Read apt.dat only according to scenery_packs.ini (which includes the big apt.dat in "Custom Scenery/Global Scenery/" folder)
- Skip duplicate airports - first wins according to the order in scenery_packs.ini 

Now we have 170 airports less - those which were only found in the apt.dat from Resources/default scenery/default apt dat
On the other hand, loading both big apt.dat files would take 1 minute.
So currently there doesn't seem to be an alternative.